### PR TITLE
Fix Flex games descriptions

### DIFF
--- a/src/components/Steps/Layout/index.tsx
+++ b/src/components/Steps/Layout/index.tsx
@@ -49,7 +49,7 @@ export default function Layout(): JSX.Element {
                   <p>Flexbox Defense</p>
                 </a>
               </span>
-              <p>Game to get better using Flexbox by repositioning a frog within its pond.</p>
+              <p>Fun game where your job is to stop the incoming enemies from getting past your defenses using Flexbox to stop them.</p>
             </li>
             <li>
               <span className="linkUnderline">
@@ -57,7 +57,7 @@ export default function Layout(): JSX.Element {
                   <p>Flexbox Froggy</p>
                 </a>
               </span>
-              <p>Fun game where your job is to stop the incoming enemies from getting past your defenses using Flexbox to stop them.</p>
+              <p>Game to get better using Flexbox by repositioning a frog within its pond.</p>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
Just noticed this small mistake with the description of the links while using your course as a reference :)

<img width="947" alt="Screen Shot 2020-06-21 at 2 37 19 PM" src="https://user-images.githubusercontent.com/2347974/85233549-d49d4b80-b3cc-11ea-9880-7af188b0a801.png">
